### PR TITLE
#2 sets non_committal_ table primary key type to match table id column type

### DIFF
--- a/lib/noncommittal.rb
+++ b/lib/noncommittal.rb
@@ -7,13 +7,18 @@ module Noncommittal
     tables ||= __gather_default_tables
     tables = tables.map(&:to_s) - exclude_tables.map(&:to_s)
 
+    table_id_types = tables.map do |table|
+      id_column = ActiveRecord::Base.connection.columns(table).find { |col| col.name == 'id' }
+      id_column ? [table, id_column.sql_type] : nil
+    end.compact.to_h
+
     ActiveRecord::Base.connection.execute <<~SQL
-      create table if not exists noncommittal_no_rows_allowed (id bigint unique);
-      #{tables.map { |table_name|
-        constraint_name = "noncommittal_#{table_name}"
+      #{table_id_types.map { |table_name, id_type|
+        constraint_name = "constrain_noncommittal_#{table_name}"
         <<~SQL
+          create table if not exists noncommittal_no_rows_allowed_#{table_name} (id #{id_type} unique);
           alter table #{table_name} drop constraint if exists #{constraint_name};
-          alter table #{table_name} add constraint #{constraint_name} foreign key (id) references noncommittal_no_rows_allowed (id) deferrable initially deferred;
+          alter table #{table_name} add constraint #{constraint_name} foreign key (id) references noncommittal_no_rows_allowed_#{table_name} (id) deferrable initially deferred;
         SQL
       }.join("\n")}
     SQL


### PR DESCRIPTION
This supports UUID primary key types, and, also supports those whose legacy databases have tables with varying primary key field types.